### PR TITLE
chore: fix dead link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,5 +24,5 @@ Magma is based on **NeoForge and Spigot**, meaning it can run both **Craftbukkit
 Coming soon we will have a full guide on how to install Magma once we have a ready release.
 
 [Discord]: https://discord.gg/magma
-[Documentation]: https://docs.magmafoundation.org
+[Documentation]: https://magmafoundation.org/docs
 [Download]: https://magmafoundation.org


### PR DESCRIPTION
Fixing dead link to documentation which points to the sub-domain which doesn't seems to be available anymore.